### PR TITLE
fix: add guidance on properly quoting mermaid node labels

### DIFF
--- a/rules/planning-execution.mdc
+++ b/rules/planning-execution.mdc
@@ -32,6 +32,7 @@ Create visual diagrams using Mermaid syntax (in fenced code blocks marked with `
 - Use `graph LR` (left-right) for user flow sequences
 - Group related components using `subgraph` containers
 - Maintain consistent visual hierarchy and spacing
+- **Always quote node labels** with double quotes: `A["Node Label"]`. If labels must contain double quotes, use HTML entity `#quot;` but avoid this if possible.
 
 ### Visual Elements for Rapid Scanning
 ```
@@ -50,24 +51,24 @@ Create visual diagrams using Mermaid syntax (in fenced code blocks marked with `
 Use re-usable classes for consistent styling:
 ```mermaid
 graph TD
-%% Define style classes once
-classDef goal fill:#e1f5fe,stroke:#01579b;
-classDef done fill:#e8f5e8,stroke:#2e7d32;
-classDef tech fill:#f3e5f5,stroke:#7b1fa2;
-classDef ux fill:#e8eaf6,stroke:#3f51b5;
-classDef risk fill:#ffebee,stroke:#c62828;
-classDef iterative fill:#fff3e0,stroke:#ef6c00;
-classDef dataflow fill:#f1f8e9,stroke:#558b2f;
-classDef integration fill:#fce4ec,stroke:#ad1457;
+    %% Define style classes once
+    classDef goal fill:#e1f5fe,stroke:#01579b;
+    classDef done fill:#e8f5e8,stroke:#2e7d32;
+    classDef tech fill:#f3e5f5,stroke:#7b1fa2;
+    classDef ux fill:#e8eaf6,stroke:#3f51b5;
+    classDef risk fill:#ffebee,stroke:#c62828;
+    classDef iterative fill:#fff3e0,stroke:#ef6c00;
+    classDef dataflow fill:#f1f8e9,stroke:#558b2f;
+    classDef integration fill:#fce4ec,stroke:#ad1457;
 
-%% Use classes on nodes
-	A[🎯 Main Goal]:::goal --> B[🔧 Tech Component]:::tech
-	B --> C[🎨 User Interface]:::ux
-	C --> D[✅ Completed]:::done
-	E[📊 Data Processing]:::dataflow --> B
-	F[🌐 API Integration]:::integration --> B
-	G[⚠️ Risk Area]:::risk
-	H[🔄 Recurring Process]:::iterative
+    %% Use classes on nodes
+    A["🎯 User Dashboard (v2.0)"]:::goal --> B["🔧 Backend API"]:::tech
+    B --> C["🎨 Frontend Components"]:::ux
+    B --> D["✅ Authentication [OAuth]"]:::done
+    C --> E["📊 Data Processing (real-time)"]:::dataflow
+    C --> F["🌐 Third-party API (Stripe)"]:::integration
+    G["⚠️ Database Migration [PostgreSQL → MongoDB]"]:::risk
+    H["🔄 Auto-refresh (30s intervals)"]:::iterative
 ```
 
 ## Phase 2: Task List Creation

--- a/rules/visual-planning.mdc
+++ b/rules/visual-planning.mdc
@@ -24,6 +24,7 @@ description: Comprehensive visual planning for complex multi-component implement
 ### Visual conventions:
 - Use `graph TD` (top-down) for architecture diagrams; use `graph LR` (left-right) for user flow sequences
 - Include emojis for visual scanning (🎯 for goals, ✅ for completed, 🔧 for technical, etc.)
+- Always quote node labels with double quotes: `A["Node Label"]`. If labels must contain double quotes, use HTML entity `#quot;` but avoid this if possible.
 - Color-code different types of nodes with `style` statements
 - Group related items logically
 - Show both technical implementation and user-facing benefits


### PR DESCRIPTION
* fix(rules/planning-execution): add guidance on properly quoting mermaid node labels
* fix(rules/visual-planning): add guidance on properly quoting mermaid node labels

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified visual-planning guidance: always quote Mermaid node labels with double quotes to handle special characters.
  * Updated example diagram to use consistent quoting and more descriptive labels for affected nodes, preventing rendering errors.
  * Adjusted diagram formatting for readability while preserving diagram structure and connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->