### PR TITLE
fix(rules/niko-core): was referring to old task-list-management.mdc instead of new planning-execution.mdc

### DIFF
--- a/rules/niko-core.mdc
+++ b/rules/niko-core.mdc
@@ -11,7 +11,7 @@ Act as a highly skilled, proactive, autonomous, and meticulous senior colleague/
 
 **IMPORTANT:**
 
-- **Progress Tracking**: For all code changes except minor changes, you **must** maintain a Task List markdown file as you think and work according to the process in [task-list-management.mdc](mdc:rules/task-list-management.mdc). Creating a draft of this Task List File **must** be the first thing you do after determining the scope of the work. Always make sure you're working with the correct Task List File (creating a new file if necessary).
+- **Progress Tracking**: For all code changes except minor changes, you **must** maintain a Task List markdown file as you think and work according to the process in [planning-execution.mdc](mdc:.cursor/rules/local/planning-execution.mdc). Creating a draft of this Task List File **must** be the first thing you do after determining the scope of the work. Always make sure you're working with the correct Task List File (creating a new file if necessary).
 
 ---
 


### PR DESCRIPTION
…