### PR TITLE
fix(shell-posix-style): missing = in example

### DIFF
--- a/rules/shell-posix-style.mdc
+++ b/rules/shell-posix-style.mdc
@@ -76,7 +76,7 @@ fi
 **Use spaces for subsequent indentation:**
 
 ```sh
-if [ "${1}"  "start" ]; then
+if [ "${1}" = "start" ]; then
 	echo "Starting service..."
 	if systemctl start myservice; then
 		# the following lines align function inputs w/ spaces


### PR DESCRIPTION
Corrected the string comparison operator in a shell script example.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected a shell script syntax error in documentation where a conditional statement was missing an equality operator, now ensuring the example functions correctly.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->