### PR TITLE
fix(niko): typo in /qa command in some places

### DIFF
--- a/rulesets/niko/commands/niko/build.md
+++ b/rulesets/niko/commands/niko/build.md
@@ -64,7 +64,7 @@ Load: .cursor/rules/shared/niko/Level4/phased-implementation.mdc
    - For Level 3-4: Verify creative phase documents exist
    - Review implementation plan
    
-   **Note**: BUILD mode is blocked until QA validation passes. If QA validation has not been completed, the system will prompt you to run `/q` first.
+   **Note**: BUILD mode is blocked until QA validation passes. If QA validation has not been completed, the system will prompt you to run `/qa` first.
 
 2. **Determine Complexity Level**
    - Read complexity level from `memory-bank/tasks.md`

--- a/rulesets/niko/commands/niko/creative.md
+++ b/rulesets/niko/commands/niko/creative.md
@@ -89,5 +89,5 @@ Type `/creative` to start creative design work for components flagged in the pla
 
 ## Next Steps
 
-After all creative phases complete, proceed to `/q` command for technical validation, then `/build` command for implementation.
+After all creative phases complete, proceed to `/qa` command for technical validation, then `/build` command for implementation.
 

--- a/rulesets/niko/commands/niko/qa.md
+++ b/rulesets/niko/commands/niko/qa.md
@@ -152,17 +152,17 @@ Load: .cursor/rules/shared/niko/visual-maps/van_mode_split/van-qa-utils/common-f
 
 ## Usage
 
-Type `/q` to perform technical validation before implementation.
+Type `/qa` to perform technical validation before implementation.
 
 **Typical Workflow:**
 ```
-/plan → /creative → /q → /build
+/plan → /creative → /qa → /build
 ```
 
 ## Next Steps
 
 - **On Success**: Proceed to `/build` command for implementation
-- **On Failure**: Fix identified issues and re-run `/q` until validation passes
+- **On Failure**: Fix identified issues and re-run `/qa` until validation passes
 
 **Note**: BUILD mode will be blocked until QA validation passes. The system checks `memory-bank/.qa_validation_status` before allowing BUILD mode access.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated QA command trigger references from `/q` to `/qa` across workflow documentation for consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->