### PR TITLE
fix(niko): allow plain /niko to reenter L4 workflows

### DIFF
--- a/rulesets/niko/niko/core/complexity-analysis.mdc
+++ b/rulesets/niko/niko/core/complexity-analysis.mdc
@@ -144,7 +144,7 @@ Create a stub file with the task name. Do **not** populate checklists yet - the 
 
 **`memory-bank/active/progress.md`** - Initialize if absent:
 
-Include a brief summary of the work to be done as described in the project brief - you've just *completed* complexity analysis!
+Include a brief summary of the work to be done as described in the project brief, followed by `**Complexity:** Level N`. This is the **system of record** for the task's complexity level — other files may display it, but `progress.md` is the canonical source.
 
 ## Step 5: Log Progress
 

--- a/rulesets/niko/niko/level2/level2-plan.mdc
+++ b/rulesets/niko/niko/level2/level2-plan.mdc
@@ -18,7 +18,7 @@ Read:
 ## Step 2: Verify Prerequisites
 
 - Confirm `memory-bank/active/tasks.md` exists (stub created by `/niko` - it will contain the task name but not yet a full plan; that's this document's job)
-- Confirm `memory-bank/active/activeContext.md` exists and indicates that the current task is indeed a Level 2 (Simple Enhancement) task
+- Confirm `memory-bank/active/progress.md` exists and its `**Complexity:**` field indicates Level 2 (Simple Enhancement)
 - Confirm `memory-bank/active/projectbrief.md` exists with the user story and requirements
 
 🚨 If any of the prerequisites are missing, STOP and inform the user (see "Output to Operator" below).

--- a/rulesets/niko/niko/level3/level3-plan.mdc
+++ b/rulesets/niko/niko/level3/level3-plan.mdc
@@ -20,7 +20,7 @@ Also read any existing creative phase documents in `memory-bank/active/creative/
 ## Step 2: Verify Prerequisites
 
 - Confirm `memory-bank/active/tasks.md` exists (stub created by `/niko`)
-- Confirm `memory-bank/active/activeContext.md` exists and indicates Level 3
+- Confirm `memory-bank/active/progress.md` exists and its `**Complexity:**` field indicates Level 3
 - Confirm `memory-bank/active/projectbrief.md` exists with the user story and requirements
 
 🚨 If any prerequisites are missing, STOP and inform the operator (see "Output to Operator" below).

--- a/rulesets/niko/niko/memory-bank/active/progress.mdc
+++ b/rulesets/niko/niko/memory-bank/active/progress.mdc
@@ -32,6 +32,8 @@ Create the file in Markdown format, according to this template:
 
 Short, high-level summary of the work that needs to be done in order to complete the work laid out in the `memory-bank/active/projectbrief.md` file.
 
+**Complexity:** Level [N]
+
 ## [Date] - [Phase] - [Status]
 
 * Work completed

--- a/rulesets/niko/skills/niko-archive/SKILL.md
+++ b/rulesets/niko/skills/niko-archive/SKILL.md
@@ -15,9 +15,9 @@ Read:
 
 ## Step 2: Determine Complexity Level
 
-Read the complexity level from `memory-bank/active/activeContext.md`.
+Read the complexity level from `memory-bank/active/progress.md` (the `**Complexity:**` field).
 
-If no complexity level is set, or `memory-bank/active/activeContext.md` does not exist: 🛑 STOP! It doesn't make sense to archive before a task has been completed.
+If no complexity level is set, or `memory-bank/active/progress.md` does not exist: 🛑 STOP! It doesn't make sense to archive before a task has been completed.
 
 Ask the operator for clarification, and wait for their instructions. You're done for now.
 

--- a/rulesets/niko/skills/niko-build/SKILL.md
+++ b/rulesets/niko/skills/niko-build/SKILL.md
@@ -15,9 +15,9 @@ Read:
 
 ## Step 2: Determine Complexity Level
 
-Read the complexity level from `memory-bank/active/activeContext.md`.
+Read the complexity level from `memory-bank/active/progress.md` (the `**Complexity:**` field).
 
-If no complexity level is set, or `memory-bank/active/activeContext.md` does not exist: STOP BUILDING! Invoke the `niko` skill to initialize the memory bank and perform complexity analysis.
+If no complexity level is set, or `memory-bank/active/progress.md` does not exist: STOP BUILDING! Invoke the `niko` skill to initialize the memory bank and perform complexity analysis.
 
 ## Step 3: Route to Level-Specific Build
 

--- a/rulesets/niko/skills/niko-plan/SKILL.md
+++ b/rulesets/niko/skills/niko-plan/SKILL.md
@@ -15,9 +15,9 @@ Read:
 
 ## Step 2: Determine Complexity Level
 
-Read the complexity level from `memory-bank/active/activeContext.md`
+Read the complexity level from `memory-bank/active/progress.md` (the `**Complexity:**` field).
 
-If no complexity level is set, or `memory-bank/active/activeContext.md` does not exist: STOP PLANNING! Invoke the `niko` skill to initialize the memory bank and perform complexity analysis, then proceed as instructed there.
+If no complexity level is set, or `memory-bank/active/progress.md` does not exist: STOP PLANNING! Invoke the `niko` skill to initialize the memory bank and perform complexity analysis, then proceed as instructed there.
 
 ## Step 3: Route to Level-Specific Planning
 

--- a/rulesets/niko/skills/niko-reflect/SKILL.md
+++ b/rulesets/niko/skills/niko-reflect/SKILL.md
@@ -15,9 +15,9 @@ Read:
 
 ## Step 2: Determine Complexity Level
 
-Read the complexity level from `memory-bank/active/activeContext.md`.
+Read the complexity level from `memory-bank/active/progress.md` (the `**Complexity:**` field).
 
-If no complexity level is set, or `memory-bank/active/activeContext.md` does not exist: 🛑 STOP! It doesn't make sense to reflect before a task has been completed.
+If no complexity level is set, or `memory-bank/active/progress.md` does not exist: 🛑 STOP! It doesn't make sense to reflect before a task has been completed.
 
 Ask the operator for clarification, and wait for their instructions. You're done for now.
 

--- a/rulesets/niko/skills/niko/SKILL.md
+++ b/rulesets/niko/skills/niko/SKILL.md
@@ -44,7 +44,7 @@ If the user provided task input, skip to Step 3.
 When `/niko` is invoked with no user input, check for existing in-flight work:
 
 1. **L4 in-flight:** If `memory-bank/active/milestones.md` exists, an L4 project is active. Proceed to Step 3 — complexity analysis handles L4 re-entry.
-2. **L1-L3 in-flight:** If all four ephemeral files exist (`projectbrief.md`, `activeContext.md`, `tasks.md`, `progress.md`) but `milestones.md` does not, read `activeContext.md` to determine the current complexity level and phase. Load the appropriate level-specific workflow and resume execution from the current phase.
+2. **L1-L3 in-flight:** If all four ephemeral files exist (`projectbrief.md`, `activeContext.md`, `tasks.md`, `progress.md`) but `milestones.md` does not, read `progress.md` for the `**Complexity:**` field (the level) and `activeContext.md` for the `**Phase:**` field (the current phase). Load the appropriate level-specific workflow and resume execution from the current phase.
 3. **No work in-flight:** Nothing to resume. Exit and do nothing else.
 
 ## Step 3: Determine Complexity Level


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated workflow docs with clearer step names, decision points, and guidance for resuming, reflecting, archiving, and reworking tasks.

* **Improvements**
  * Restructured re-entry/resume flows to distinguish completed-reflection vs in-progress work, adding explicit checkpoints and dual exit paths.
  * Readiness checks now use the progress template's Complexity field to determine level-specific behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->