### PR TITLE
fix(niko): Add preflight validation: plan to do TDD

### DIFF
--- a/rulesets/niko/skills/niko-preflight/SKILL.md
+++ b/rulesets/niko/skills/niko-preflight/SKILL.md
@@ -5,7 +5,7 @@ description: Niko Memory Bank System - Preflight Phase - Pre-Build Plan Validati
 
 # Preflight Phase - Pre-Build Plan Validation
 
-This command validates the implementation plan against codebase reality before any code is written. It catches design oversights, convention conflicts, and integration issues that would otherwise surface during or after the build.
+This command validates the implementation plan against codebase reality before any code is written. It catches design oversights, convention conflicts, TDD violations, and integration issues that would otherwise surface during or after the build.
 
 ## Step 1: Load Memory Bank Files
 
@@ -23,42 +23,48 @@ Read:
    - For Level 3-4: Verify creative phase documents exist (if creative phases were flagged)
    - Read implementation plan and design decisions
 
-2. **Convention Compliance**
+2. **TDD Plan Encoding** *(blocking)*
+   - The test-first process lives in `.cursor/rules/shared/always-tdd.mdc`
+   - For each implementable unit of work (function, slice, milestone — whatever granularity the plan uses), confirm the ordered substeps place test-writing before production code, explicitly enough that a reasonable implementer cannot follow the plan by coding first
+   - FAIL when numbered steps are implementation-only under a "we follow TDD" disclaimer; when any step explicitly orders implementation before tests; or when TDD ordering lives only in the plan's preamble rather than per-unit
+
+3. **Convention Compliance**
    - Verify the plan's proposed file locations, naming conventions, and patterns align with established codebase conventions documented in `memory-bank/systemPatterns.md`
    - Cross-reference proposed module structure against existing project organization
    - Flag any deviation from established patterns with specific recommendations
 
-3. **Dependency Impact**
+4. **Dependency Impact**
    - Trace the plan's touchpoints through the dependency graph
    - Identify modules, consumers, or tests that will be affected but aren't accounted for in the plan
    - Verify that all downstream impacts are documented and addressed
 
-4. **Conflict Detection**
+5. **Conflict Detection**
    - Search for existing implementations, utilities, or patterns that overlap with or contradict the plan's approach
    - Identify duplication-in-waiting - cases where the plan proposes building something the codebase already provides
    - Flag any proposed changes that would break public contracts or published interfaces — internal restructuring that preserves the public API surface is not a conflict
 
-5. **Completeness Precheck**
+6. **Completeness Precheck**
    - Verify the plan addresses all stated requirements with concrete implementation steps mapped to each one - not aspirationally, but with specific files, functions, and approaches identified
    - Flag any requirements that are acknowledged but lack a clear implementation path
    - Verify test coverage is planned for all new behavior
 
-6. **Radical Innovation** *(advisory - not blocking)*
+7. **Radical Innovation** *(advisory - not blocking)*
     - What's the single smartest and most radically innovative and accretive and useful and compelling change you could make to the plan at this point?
     - Describe the change concretely - not as a vague suggestion, but as a specific structural sketch the operator can evaluate against the cost of redesign.
     - If the change can be made within the current workflow's complexity level and within the current Project Brief's scope, make the change to the plan.
     - If the change would change the complexity level of the task *or* if the change would significantly deviate from the current Project Brief's scope, flag it as an advisory finding for operator consideration but do not make the change.
 
-7. **Generate Preflight Report**
+8. **Generate Preflight Report**
    - Create comprehensive findings report
    - Write validation status to `memory-bank/active/.preflight-status`
    - Update `memory-bank/active/tasks.md` with any plan amendments or findings
 
-8. **Handle Results**
+9. **Handle Results**
    - **On PASS**: Good job!
    - **On PASS with ADVISORY**: Allow transition to `/niko-build`, but document advisory findings for the operator's consideration
    - **On FAIL (rearchitect needed)**: Operator decision required.
    - **On FAIL (conflict/convention)**: Provide specific fix instructions, block `/niko-build`; Operator decision required.
+   - **On FAIL (TDD plan encoding)**: Block `/niko-build`; cite the unit(s) that lack explicit test-before-code ordering and re-run `/niko-plan` to restructure them.
 
 ## Step 3: Log Progress
 


### PR DESCRIPTION
We require TDD. The plan says so, and the `always-tdd` rule says so.

And yet, sometimes agents don't.

Preflight should catch a plan that doesn't spell out explicit TDD practices in accordance with our rule. Previously, bad plans that could be done w/out TDD, slipped through.

QA could maybe do with a "did you TDD" check, but the fix there is to REDO the build, which we hope to avoid by just catching it early. Probably DOES need to be there eventually though. Later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added TDD Plan Encoding validation that enforces explicit test-before-code ordering in development plans
  * Validation now blocks builds when test-first ordering is not properly followed
  * Provides clear guidance to restructure plans when TDD encoding requirements are unmet

<!-- end of auto-generated comment: release notes by coderabbit.ai -->