### PR TITLE
docs(niko): reframe memory-bank-paths around a positive VCS-tracking principle

### DIFF
--- a/memory-bank/active/activeContext.md
+++ b/memory-bank/active/activeContext.md
@@ -1,0 +1,6 @@
+# Active Context
+
+- **Current Task:** Positive-principle reframe for memory-bank VCS tracking
+- **Phase:** BUILD - COMPLETE
+- **What Was Done:** Added a top-of-section guiding principle to `rulesets/niko/niko/core/memory-bank-paths.mdc` asserting that every file under `memory-bank/` is a versioned artifact; reframed persistent/ephemeral as a lifetime distinction; folded the redundant line-33 patch into the principle.
+- **Next Step:** QA — verify the rule prose reads correctly and the failure-mode framing is addressed.

--- a/memory-bank/active/progress.md
+++ b/memory-bank/active/progress.md
@@ -1,0 +1,10 @@
+# Progress
+
+Brief: Add a positive-principle reframe to `memory-bank-paths.mdc` so that the rule states once, near the top, that every file under `memory-bank/` is a tracked, versioned artifact. This eliminates the failure mode where models read "ephemeral" as "should not be committed."
+
+**Complexity:** Level 1
+
+## History
+
+- Complexity analysis complete — single-file rule edit, no architectural impact.
+- Build complete — added the **Guiding principle** paragraph at the top of the `CORE MEMORY BANK FILE LOCATIONS` section and trimmed the now-redundant tracking sentence at the bottom of the Ephemeral section.

--- a/memory-bank/active/projectbrief.md
+++ b/memory-bank/active/projectbrief.md
@@ -1,0 +1,19 @@
+# Project Brief: Positive-Principle Reframe for Memory Bank VCS Tracking
+
+## User Story
+
+As the operator of the Niko ruleset, I want the `memory-bank-paths.mdc` rule to state — as a positive guiding principle near the top of the file — that the memory bank is a tracked working tree of context and every file under `memory-bank/` is a versioned artifact. This eliminates the failure mode where some AI models, primed by the word "ephemeral," exclude `memory-bank/active/` files from commits or add them to `.gitignore`.
+
+## Requirements
+
+- Add a positive-principle statement near the top of the `CORE MEMORY BANK FILE LOCATIONS` section in `rulesets/niko/niko/core/memory-bank-paths.mdc` asserting that every file under `memory-bank/` is a tracked, versioned artifact.
+- Reframe the persistent/ephemeral split as a *lifetime* distinction, not a *durability-in-VCS* distinction.
+- Do NOT rename the "ephemeral" category — the operator considers a rename too high-churn for a long-tail failure mode.
+- Do NOT add anti-pattern callouts ("don't gitignore", "don't skip commits"). The positive principle should make those fall out automatically.
+- Fold the existing corrective sentence (current line 33) into the new framing so the rule isn't redundant.
+
+## Out of Scope
+
+- Renaming "ephemeral" to anything else.
+- Editing other rule files, skills, or memory-bank prose that use the word "ephemeral".
+- Adding an `AGENTS.md` or per-directory README in `memory-bank/active/`.

--- a/memory-bank/active/tasks.md
+++ b/memory-bank/active/tasks.md
@@ -1,0 +1,20 @@
+# Tasks: Positive-Principle Reframe for Memory Bank VCS Tracking
+
+## What broke
+
+Some AI models read the word "ephemeral" in `rulesets/niko/niko/core/memory-bank-paths.mdc` as "should not be committed to VCS." Observed failure modes: skipping `memory-bank/active/` files when staging commits; adding `memory-bank/active/` to `.gitignore`.
+
+## Why
+
+The rule named one category by a property ("ephemeral") that is semantically loaded toward *throwaway / not durable* in dev contexts. A previous corrective sentence at the bottom of the Ephemeral section told models to commit the files anyway, but it fights the noun rather than removing the ambiguity.
+
+## What changed
+
+`rulesets/niko/niko/core/memory-bank-paths.mdc`:
+
+- Added a **Guiding principle** paragraph immediately after the `**CRITICAL:**` opener: *"The memory bank is the project's tracked working tree of context. Every file under `memory-bank/` is a versioned artifact — created, modified, and committed to source control as work progresses, and pruned only by an explicit archive step. The categories below distinguish files by lifetime (does this survive across tasks?), not by durability in source control."*
+- Rewrote the trailing sentence in the Ephemeral section to keep only the lifetime semantics (execution trace, cleaned up by archive phase) and drop the now-redundant VCS-tracking reassurance.
+
+## Files affected
+
+- `rulesets/niko/niko/core/memory-bank-paths.mdc`

--- a/rulesets/niko/niko/core/memory-bank-paths.mdc
+++ b/rulesets/niko/niko/core/memory-bank-paths.mdc
@@ -19,7 +19,7 @@ These files contain relatively stable information and persist across tasks to gu
 
 ## Ephemeral Files
 
-These files are scoped to the current task, will be updated as the task progresses, and will be cleaned up (usually by an `archive` phase) when the operator judges they are no longer needed. They serve as an execution trace for the current tasks' work.
+These files are scoped to the current task, will be updated as the task progresses, and will be cleaned up (usually by an `archive` phase) when the operator judges they are no longer needed. They serve as an execution trace for the current task's work.
 
 * **Project Brief File:** `memory-bank/active/projectbrief.md` - Current session deliverable: user story & requirements. This guides all development.
 * **Active Context File:** `memory-bank/active/activeContext.md` - Current session focus: what's being worked on now, recent decisions, immediate next steps. A pointer to the current phase.

--- a/rulesets/niko/niko/core/memory-bank-paths.mdc
+++ b/rulesets/niko/niko/core/memory-bank-paths.mdc
@@ -6,7 +6,7 @@ alwaysApply: true
 
 **CRITICAL:** All core Memory Bank files reside within the `memory-bank/` directory at the project root. Do NOT create or modify these files outside this directory unless explicitly instructed for archiving purposes.
 
-**Guiding principle:** The memory bank is the project's tracked working tree of context. **Every file under `memory-bank/` is a versioned artifact** — created, modified, and committed to source control as work progresses. The categories below distinguish files by *lifetime* (does this survive across tasks?), not by durability in source control.
+**Guiding principle:** The memory bank is the project's tracked working tree of context. **Every file under `memory-bank/` is a versioned artifact** - created, modified, and committed to source control as work progresses. The categories below distinguish files by *lifetime* (does this survive across tasks?), not by durability in source control.
 
 ## Persistent Files
 

--- a/rulesets/niko/niko/core/memory-bank-paths.mdc
+++ b/rulesets/niko/niko/core/memory-bank-paths.mdc
@@ -6,7 +6,7 @@ alwaysApply: true
 
 **CRITICAL:** All core Memory Bank files reside within the `memory-bank/` directory at the project root. Do NOT create or modify these files outside this directory unless explicitly instructed for archiving purposes.
 
-**Guiding principle:** The memory bank is the project's tracked working tree of context. **Every file under `memory-bank/` is a versioned artifact** — created, modified, and committed to source control as work progresses, and pruned only by an explicit archive step. The categories below distinguish files by *lifetime* (does this survive across tasks?), not by durability in source control.
+**Guiding principle:** The memory bank is the project's tracked working tree of context. **Every file under `memory-bank/` is a versioned artifact** — created, modified, and committed to source control as work progresses. The categories below distinguish files by *lifetime* (does this survive across tasks?), not by durability in source control.
 
 ## Persistent Files
 
@@ -19,7 +19,7 @@ These files contain relatively stable information and persist across tasks to gu
 
 ## Ephemeral Files
 
-These files are scoped to the current task, and will be updated as the task progresses.
+These files are scoped to the current task, will be updated as the task progresses, and will be cleaned up (usually by an `archive` phase) when the operator judges they are no longer needed. They serve as an execution trace for the current tasks' work.
 
 * **Project Brief File:** `memory-bank/active/projectbrief.md` - Current session deliverable: user story & requirements. This guides all development.
 * **Active Context File:** `memory-bank/active/activeContext.md` - Current session focus: what's being worked on now, recent decisions, immediate next steps. A pointer to the current phase.
@@ -31,8 +31,6 @@ These files are scoped to the current task, and will be updated as the task prog
 * **QA Validation Status:** `memory-bank/active/.qa-validation-status` - Task-specific QA validation status file (created by `/niko-qa`, gates `/niko-reflect` for L2+ tasks)
 * **L4 Milestone List:** `memory-bank/active/milestones.md` - L4-only. Ordered checklist of milestones for the current L4 project, each of which will be handled by separate L1/L2/L3 sub-runs. Deleted by the capstone archive phase when all milestones are done.
 * **Troubleshooting Docs:** `memory-bank/active/troubleshooting/troubleshooting-<YYYYMMDD-HHmmss>.md` - Diagnostic scratch notes from `/nk-refresh`. Deleted (not inlined) during archive; distilled learning belongs in the reflection.
-
-Ephemeral files are an execution trace of the current task. They are cleaned up (usually by an `archive` phase) when the operator judges they are no longer needed.
 
 **Verification Mandate:** Before any `create_file` or `edit_file` operation on core files, verify the path is correct for the file type:
 - **Persistent files** must reside directly under `memory-bank/` (e.g., `memory-bank/systemPatterns.md`).

--- a/rulesets/niko/niko/core/memory-bank-paths.mdc
+++ b/rulesets/niko/niko/core/memory-bank-paths.mdc
@@ -6,6 +6,8 @@ alwaysApply: true
 
 **CRITICAL:** All core Memory Bank files reside within the `memory-bank/` directory at the project root. Do NOT create or modify these files outside this directory unless explicitly instructed for archiving purposes.
 
+**Guiding principle:** The memory bank is the project's tracked working tree of context. **Every file under `memory-bank/` is a versioned artifact** — created, modified, and committed to source control as work progresses, and pruned only by an explicit archive step. The categories below distinguish files by *lifetime* (does this survive across tasks?), not by durability in source control.
+
 ## Persistent Files
 
 These files contain relatively stable information and persist across tasks to guide & inform development and design:
@@ -29,6 +31,8 @@ These files are scoped to the current task, and will be updated as the task prog
 * **QA Validation Status:** `memory-bank/active/.qa-validation-status` - Task-specific QA validation status file (created by `/niko-qa`, gates `/niko-reflect` for L2+ tasks)
 * **L4 Milestone List:** `memory-bank/active/milestones.md` - L4-only. Ordered checklist of milestones for the current L4 project, each of which will be handled by separate L1/L2/L3 sub-runs. Deleted by the capstone archive phase when all milestones are done.
 * **Troubleshooting Docs:** `memory-bank/active/troubleshooting/troubleshooting-<YYYYMMDD-HHmmss>.md` - Diagnostic scratch notes from `/nk-refresh`. Deleted (not inlined) during archive; distilled learning belongs in the reflection.
+
+Ephemeral files are an execution trace of the current task. They are cleaned up (usually by an `archive` phase) when the operator judges they are no longer needed.
 
 **Verification Mandate:** Before any `create_file` or `edit_file` operation on core files, verify the path is correct for the file type:
 - **Persistent files** must reside directly under `memory-bank/` (e.g., `memory-bank/systemPatterns.md`).


### PR DESCRIPTION
# Summary

1. Added a top-of-section **Guiding principle** to [rulesets/niko/niko/core/memory-bank-paths.mdc](https://github.com/Texarkanine/.cursor-rules/blob/commit-membank/rulesets/niko/niko/core/memory-bank-paths.mdc): the memory bank is the project's tracked working tree of context; every file under `memory-bank/` is a versioned artifact; persistent vs ephemeral distinguishes *lifetime*, not durability in VCS.
2. Trimmed the trailing Ephemeral paragraph so it only describes execution-trace semantics and archive cleanup (the VCS reassurance is folded into the principle).
3. Added this task's Niko memory-bank ephemeral files under [memory-bank/active/](https://github.com/Texarkanine/.cursor-rules/tree/commit-membank/memory-bank/active) as created during the Level 1 workflow.

# Description

Some models read "ephemeral" as "do not commit" or added `memory-bank/active/` to `.gitignore`. The new principle states the affirmative model first so the wrong inference does not need a growing list of negated anti-patterns.

# Testing

Documentation-only change. QA was a manual prose review; no automated test suite applies.

# Checklist
- [x] Code follows project style guidelines
- [x] Documentation updated if necessary
- [ ] Tests added or updated
- [ ] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified VCS-tracking guidance with a guiding principle affirming all memory bank files are tracked/versioned artifacts.
  * Refined "ephemeral" file definitions to emphasize lifetime and archival semantics rather than VCS durability.
  * Added project brief, progress, and task notes documenting the reframing initiative.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Texarkanine/.cursor-rules/pull/76)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->