### PR TITLE
feat(rules): add always-on conserve-context rule

### DIFF
--- a/rules/conserve-context.mdc
+++ b/rules/conserve-context.mdc
@@ -1,0 +1,27 @@
+---
+alwaysApply: true
+---
+
+# Conserve Context
+
+Everything you put in context is re-read on every subsequent model call in the turn — on the order of 20x. A 2,000-token file you didn't need costs 40,000. Read narrow, and don't read the same thing twice.
+
+## Read Only the Range You Need
+
+A bare read of a whole file is a default worth overriding. Locate with a search tool first, then read the range you found using offset and limit. Read a file whole when it is genuinely small (under ~200 lines), when you are about to rewrite it, or when you need its full structure to reason about it.
+
+## Don't Re-Read Data You Can Still See
+
+When a file's contents are still visible in context, reading it again duplicates it and tells you nothing new. Read it again when it changed — because you edited it, or because something else did — or when its contents are no longer in front of you. A note that you read a file is not the same as having it; if you need a detail and can only find a summary, read the file.
+
+## Instructions Are Not Data
+
+Re-reading a rule, workflow, or context file to bring it back to the front of context is a deliberate trade: identical bytes, better adherence. That is not duplication, and this rule does not discourage it. For data, position in context does not matter — you can look back at what you already read. For instructions, position is the payload.
+
+## Bound Output You Won't Read Whole
+
+Use the terse form of any command whose full output you are not going to read: `git status --porcelain`, `git diff --stat`, `git log --oneline`, `ls -1`, `find … | head`. If nothing has changed since a command last ran, don't run it again for an answer that is already in context.
+
+This does not govern test output.
+
+**Boundaries**: This is about not paying for the same information twice. It is never a reason to skip a read you need, guess at a file's contents, work from a stale memory of what a file said, or truncate output you are actually going to use. When correctness is in question, read it — being wrong costs more than the tokens.


### PR DESCRIPTION
# Summary

1. Adds [rules/conserve-context.mdc](https://github.com/Texarkanine/.cursor-rules/blob/feat/conserve-context/rules/conserve-context.mdc) — an always-on rule for spending context economically: bounded reads, no duplicate reads, terse command output.

Deliberately not filed into any ruleset yet. The diff against `main` is one new file.

# Description

Everything placed in context is re-read on every subsequent model call in the turn, so the marginal cost of an unnecessary read is roughly twenty times its size. The rule targets the three habits that drive that: reading whole files when a range would do, re-reading data already in context, and taking full output from commands whose result will not be read.

Resident rather than on-demand, because a skill is invoked after the agent has already decided to read — which is after the cost is incurred. Kept short for the same reason: an always-on rule pays its own token cost every turn, so it is trimmed to roughly the density of `script-it-instead.mdc`.

Three choices worth reviewing:

**Re-read avoidance is grounded on observable context, not on remembered actions.** The rule says "data you can still see," never "data you already read." Those differ after compaction: a summary may report that a file was read while its contents are gone. Phrasing it the other way would have handed the agent an authoritative reason not to look, exactly when looking is required. It also keeps the rule correct across harnesses without naming compaction or any mechanism.

**Instructions are carved out from data.** Reloading a rule or workflow file mid-task is a deliberate trade — identical bytes, better adherence — and a blanket no-re-reads rule would suppress it. Measured against ~30 days of local transcripts, roughly a quarter of same-file re-reads were workflow-directed reloads of rules and memory-bank files, and another third followed a real edit. Only about half were unexplained.

**Test output is scoped out rather than legislated.** The rule says only that it does not govern test output. It does not restate what should happen there, so it cannot drift against the rule that does, and it imposes nothing when installed alone.

# Testing

`make test` passes. Neither check exercises this change — no ruleset symlink and no ruleset README link were added — so this confirms nothing was broken rather than that anything new was verified. No behavioral tests exist for prompt content.

# Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated if necessary
- [ ] Tests added or updated
- [x] All tests pass
