### PR TITLE
fix(rules): de-emphasize TDD rules and absorb heading parentheticals

### DIFF
--- a/rules/always-tdd.mdc
+++ b/rules/always-tdd.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 ---
 # Test-Driven Development (TDD) Requirement
 
-**ALL** code changes must be made according to this test-driven development process: **TESTS GET WRITTEN FIRST!** Strictly follow the four steps laid out below, in order, for every code change. **NEVER** skip ahead to making code changes without following this process!
+All code changes must be made according to this test-driven development process: **tests get written first**. Strictly follow the four steps laid out below, in order, for every code change. Never skip ahead to making code changes without following this process.
 
 ## 1. Determine Scope
 
@@ -15,17 +15,17 @@ alwaysApply: true
 	- Determine if new test suites must be added
 	- Determine if test cases must be added to existing test suites
 	- Determine if existing test cases must be modified
-	- **IMPORTANT:** If you cannot locate existing test infrastructure, **STOP AND ASK** what to do.
+	- If you cannot locate existing test infrastructure, **stop and ask** what to do.
 
-## 2. Preparation (Stubbing)
+## 2. Stubbing
 
 1. **Stub new tests:** create any necessary test suites and/or test cases, with **empty implementations**
 	- If the test signature is not self-descriptive, include multi-line comments on the test suites and test cases explaining the behaviors they are supposed to test.
-	- **IMPORTANT:** do not implement any tests yet!
+	- Do not implement any tests yet.
 2. **Stub the interface:** add any new functions, classes, etc to the codebase with **empty implementations**
 	- include full function and/or class signatures, etc
 	- include full multi-line comment documentation in the style already in use in the project *or* the industry standard for the language(s) in use if the project has no prior art
-	- **IMPORTANT:** do not implement any of the actual code changes yet!
+	- Do not implement any of the actual code changes yet.
 3. **Modify existing tests:** modify any existing tests as needed to correctly test for the new behavior
 
 ## 3. Write Tests

--- a/rules/pr-feedback-judge/SKILL.md
+++ b/rules/pr-feedback-judge/SKILL.md
@@ -27,11 +27,11 @@ Classify each input URL by its fragment, then dispatch:
 
 If a URL doesn't match any of these shapes: emit "could not classify URL: `<url>`" for that item and continue with the rest. Do not crash, do not guess.
 
-## Tier detection (in priority order)
+## Tier Detection Order
 
 Evaluate tiers in this exact order. Use the first one available; do not fall through to a lower tier if a higher one is present.
 
-### T1 — `gh` CLI (preferred)
+### T1 — `gh` CLI
 
 Detection:
 
@@ -60,7 +60,7 @@ gh api "repos/{o}/{r}/pulls/comments/{cid}"
 gh api "repos/{o}/{r}/issues/comments/{cid}"
 ```
 
-### T2 — GitHub MCP server (fallback)
+### T2 — GitHub MCP Server
 
 Detection: scan the harness's **registered-MCP-servers list** (the same block of MCP metadata exposed to you at invocation time) for any server whose **name, identifier, or description** contains `github` (case-insensitive substring). If one matches, use its read-only PR/issue tools.
 
@@ -74,7 +74,7 @@ If neither T1 nor T2 is available, emit verbatim:
 
 Do not attempt anonymous `curl`. Do not scrape HTML. Do not pre-fetch the URL via any other path. Stop and surface the message.
 
-## The intro (always emit, before any items)
+## Intro Block
 
 Emit the following block verbatim before evaluating any items:
 
@@ -86,7 +86,7 @@ Emit the following block verbatim before evaluating any items:
 >
 > The three answers compose into a disposition. Feedback can be valid but not worth fixing, or valid and worth fixing but out of scope for *this* PR — I'll spell each one out.
 
-## The per-item block (emit for every item, in order)
+## Per-Item Block
 
 ```markdown
 ### Item N — [link to comment](url) by @author
@@ -107,7 +107,7 @@ Emit the following block verbatim before evaluating any items:
 
 Disposition vocabulary is fixed (4 values). Pick exactly one per item. Use the emoji set ✅ / ❌ / 🕒 only.
 
-## Triage table (conditional — only when item count > 5)
+## Conditional Triage Table
 
 If — and only if — the total number of items to evaluate is greater than 5 (e.g., a whole-PR URL on a busy PR), emit a compact triage table **before** the per-item blocks:
 
@@ -120,7 +120,7 @@ If — and only if — the total number of items to evaluate is greater than 5 (
 
 For 5 or fewer items, skip the table — the per-item blocks alone are clearer at that scale.
 
-## Tail (always emit, after all per-item blocks)
+## Tail Block
 
 > N items evaluated · X to fix in this PR · Y deferred · Z dismissed.
 

--- a/rules/test-running-practices.mdc
+++ b/rules/test-running-practices.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 ---
 # Best Practices for Running Tests
 
-1. **DO NOT** remove debug output from a test you were troubleshooting until you run the test with the debug output and see it pass.
-2. **DO NOT** use `head`, `tail`, `grep` or other output-filtering tools. You must **ALWAYS** read the whole test-run output, whether you're running the whole suite or an individual test.
-3. **PREFER** to run a single test case instead of the whole test suite when iterating on a single issue & you have reason to believe that your changes are constrained to what that test covers.
-4. **ALWAYS** run the whole test suite at the end before concluding work is "done."
+1. Do not remove debug output from a test you were troubleshooting until you run the test with the debug output and see it pass.
+2. Do not use `head`, `tail`, `grep` or other output-filtering tools. You must always read the whole test-run output, whether you're running the whole suite or an individual test.
+3. Prefer to run a single test case instead of the whole test suite when iterating on a single issue & you have reason to believe that your changes are constrained to what that test covers.
+4. Always run the whole test suite at the end before concluding work is "done."


### PR DESCRIPTION
# Summary

1. [rules/test-running-practices.mdc](https://github.com/Texarkanine/.cursor-rules/blob/doctor-5/rules/test-running-practices.mdc) — de-emphasized the most emphasis-dense rule in the repo (7.3 -> 0.0 bold pairs per 1k chars). All four items opened with a bolded all-caps directive.
2. [rules/always-tdd.mdc](https://github.com/Texarkanine/.cursor-rules/blob/doctor-5/rules/always-tdd.mdc) — de-emphasized amplifiers and absorbed a heading parenthetical (6.4 -> 4.3 per 1k).
3. [rules/pr-feedback-judge/SKILL.md](https://github.com/Texarkanine/.cursor-rules/blob/doctor-5/rules/pr-feedback-judge/SKILL.md) — absorbed or dropped 7 heading parentheticals.

# Description

> **Note:** the `niko-core.mdc` changes originally on this branch moved to #93 so the core personality rule can be reviewed on its own. This PR touches no other files.

Every rule body in `rules/` was measured against this repo's own two standards — [rules/prompt-authoring/SKILL.md](https://github.com/Texarkanine/.cursor-rules/blob/doctor-5/rules/prompt-authoring/SKILL.md) and [rules/markdown-style.mdc](https://github.com/Texarkanine/.cursor-rules/blob/doctor-5/rules/markdown-style.mdc) — and cross-checked against current published context-engineering guidance. 19 of 23 files were already clean.

## Emphasis drift

Bold density by the date each rule was added shows what these commits close. The 2025-era rules predate `prompt-authoring.md`'s own "reserve the absolutes" guidance; the 2026 rules already follow it.

| Rule | Added | Bold/1k before | after |
| --- | --- | --- | --- |
| test-running-practices.mdc | 2025-06-10 | 7.3 | 0.0 |
| always-tdd.mdc | 2025-06-06 | 6.4 | 4.3 |
| script-it-instead.mdc | 2026-03-29 | 4.1 | untouched |
| xy-problem/SKILL.md | 2026-07-17 | 1.0 | untouched |
| conserve-context.mdc | 2026-07-26 | 0.5 | untouched |
| prompt-authoring/SKILL.md | 2026-06-12 | 0.0 | untouched |

## Scope discipline

No instruction was weakened. In `always-tdd.mdc` and `test-running-practices.mdc` the wording is byte-identical apart from removed bold and caps, except that three redundant `**IMPORTANT:**` labels were dropped from sentences already written as imperatives. The four-step TDD ordering, the stop-and-ask gate, and both "always" clauses are intact.

In `pr-feedback-judge`, every removed parenthetical already duplicated the section's own first line. `conditional` was absorbed into the triage heading where it carries scannable meaning; the T1/T2 priority words were dropped rather than absorbed, since the tier numbering plus "Evaluate tiers in this exact order" directly below already carry it.

## Deferred

Whether `always-tdd.mdc` and `test-running-practices.mdc` should stay `alwaysApply: true` or move to progressive disclosure is left open. A TDD gate the model can decline to load is a TDD gate that gets skipped, so that is a values call rather than a cleanup.

# Testing

`make test` passes (`check-ruleset-symlinks.sh`, `check-ruleset-readme-links.sh`). Verified no inbound anchor links referenced the 8 renamed headings.

# Checklist
- [x] Code follows project style guidelines
- [ ] Documentation updated if necessary
- [ ] Tests added or updated
- [x] All tests pass


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified test-first development guidance with a more structured, step-by-step process.
  * Improved pull request feedback instructions with standardized section headings and clearer output formatting.
  * Reformatted test-running best practices into an ordered checklist while preserving existing guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->