### PR TITLE
feat(github-open-a-pull-request-gh): progressive PR template resolution

### DIFF
--- a/rules/github-open-a-pull-request-gh/SKILL.md
+++ b/rules/github-open-a-pull-request-gh/SKILL.md
@@ -21,27 +21,10 @@ This rule guides you through the process of opening a pull request.
 2. Extract ticket or issue ID if present:
 	- Parse current branch name for ticket/issue patterns (e.g., `feature/ABC-123`, `fix/issue-456`).
 	- If the branch is ahead of default, check the new commits' messages for ticket/issue references: `git --no-pager log --oneline main..HEAD`
-3. Check for a pull request template at `.github/PULL_REQUEST_TEMPLATE.md` (capitalization may vary). If no template exists, use this default:
-	```markdown
-	# Summary
-	[Summarize the important changes made in this pull request: A short numbered list sorted from "most impactful" to "least impactful"]
-
-	# Description
-
-	[Briefly explain any of the more-complex changes listed in the summary section]
-
-	# Related Issue(s)
-	[Reference any related issues using #issue-number; remove the "Related Issues" section entirely if no issues]
-
-	# Testing
-	[Describe how these changes were tested]
-
-	# Checklist
-	- [ ] Code follows project style guidelines
-	- [ ] Documentation updated if necessary
-	- [ ] Tests added or updated
-	- [ ] All tests pass
-	```
+3. Resolve the pull request template. Read **only** the template you will use — do not load the others into context:
+	1. Look in this repository first (`.github/pull_request_template.md` or `.github/PULL_REQUEST_TEMPLATE.md`; capitalization may vary). If found, use it.
+	2. If none, fetch the repository **owner's** community-health default from their `.github` repository at the same paths (e.g. `gh api "repos/<owner>/.github/contents/.github/pull_request_template.md" --jq .content`, base64-decode; try common capitalizations on 404). If found, use it.
+	3. If that is also missing, read `references/pull_request_template.md` next to this skill and use that.
 
 ## Preparation
 

--- a/rules/github-open-a-pull-request-gh/references/pull_request_template.md
+++ b/rules/github-open-a-pull-request-gh/references/pull_request_template.md
@@ -1,0 +1,39 @@
+<!-- Title: conventional commit. Squash-merge uses the title as the commit message and,
+     when the repo cuts releases from conventional commits (e.g. release-please), as the
+     changelog entry — so write it for someone reading history or CHANGELOG.md. feat/fix
+     typically cut a release in those setups; chore typically does not. -->
+
+## Goal
+
+<!-- What this needs to accomplish, in a line. If there's an issue, "closes #N" plus a clause
+     is plenty — the issue is already the goal statement. -->
+
+## What's here
+
+<!-- Write this last, against the branch as it stands — not the plan you opened with.
+     If it ended up somewhere other than the Goal (scope added or dropped, an approach
+     abandoned, something deferred to a follow-up), that sentence is the most useful one in
+     this PR. An undisclosed gap between these two is how surprises land in review. -->
+
+## How I know it works
+
+<!-- What convinced you this does what the Goal says — tests you ran, a manual check,
+     a transcript, or reasoning when none of those apply. Name them. Repos differ: some
+     have CI, some don't; some have no automated tests at all. Unstated is not an answer. -->
+
+**Evidence:**
+
+<details>
+<summary>Transcript</summary>
+
+```
+
+```
+
+</details>
+
+## What changes for a user
+
+<!-- Anything a user can notice or depend on: CLI flags and output shapes, API or config
+     surface, docs, setup steps, env vars. "Nothing user-visible" is a common and useful
+     answer. If something did change, say so where a user would look. -->


### PR DESCRIPTION
## Goal

Teach the open-a-PR skill to resolve a PR template via progressive disclosure: repo → owner `.github` → skill reference — without loading the fallback body when a local template already exists.

## What's here

Updates [`rules/github-open-a-pull-request-gh/SKILL.md`](https://github.com/Texarkanine/.cursor-rules/blob/feat/pr-template-reference/rules/github-open-a-pull-request-gh/SKILL.md) Information Gathering step 3 with that cascade. Moves the fallback body to [`rules/github-open-a-pull-request-gh/references/pull_request_template.md`](https://github.com/Texarkanine/.cursor-rules/blob/feat/pr-template-reference/rules/github-open-a-pull-request-gh/references/pull_request_template.md) (byte-identical to the owner `.github` community-health template). No Texarkanine hardcoding — owner is taken from the remote.

## How I know it works

**Evidence:**

- Skill step 3 names the three sources in order and says to read only the one used.
- `cmp` confirms the reference file matches `Texarkanine/.github` `.github/pull_request_template.md`.

<details>
<summary>Transcript</summary>

```
n/a — verified by inspection / git show
```

</details>

## What changes for a user

Agents following this skill load less context when a repo already has a PR template; when it does not, they inherit the owner default or the skill reference.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved pull request template guidance to prioritize repository-specific templates.
  * Added a structured fallback template with sections for goals, changes, validation, and user impact.
  * Included guidance for conventional commit titles and supporting evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->