### PR TITLE
chore: add REUSE compliance badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Cursor Rules
 
+[![REUSE status](https://api.reuse.software/badge/github.com/Texarkanine/.cursor-rules)](https://api.reuse.software/info/github.com/Texarkanine/.cursor-rules)
+
 Canonical, composable customizations for AI coding agents: rules, skills, and the rulesets that bundle them. Each behavior is authored once, here, and installed wherever it's needed — so your agents act the same way across every project, and improvements land everywhere at once.
 
 You could use them on your own, or install and manage them with the [ai-rizz](https://github.com/texarkanine/ai-rizz) tool. You might also enjoy being able to [see them rendered as Markdown on GitHub](https://github.com/Texarkanine/client-side-mdc-render). If you don't use Cursor, maybe you can convert them to the tool you *do* use (like Claude Code) with [a16n](https://npmjs.com/a16n).


### PR DESCRIPTION
## Goal

Surface existing REUSE compliance on the README badge row.

## What's here

Adds the REUSE status badge to [README.md](https://github.com/Texarkanine/.cursor-rules/blob/docs/reuse-badge/README.md). No licensing file changes; the repo already passes `reuse lint`.

## How I know it works

**Evidence:**

`reuse lint` exit 0 on the branch before opening the PR.

<details>
<summary>Transcript</summary>

```

```

</details>

## What changes for a user

README shows a REUSE compliance badge linking to the REUSE API info page.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a REUSE compliance status badge linking to the project’s REUSE information page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->